### PR TITLE
improve bug in array remove method

### DIFF
--- a/incorrect_array_remove_method/incorrect_array_remove_method.rb
+++ b/incorrect_array_remove_method/incorrect_array_remove_method.rb
@@ -13,10 +13,10 @@
 
 #removing all odd numbers from an array
 def remove_odd_numbers_from_array(a)
-  a.delete_if{|x| x % 2 == 1}
+  return a.delete_if{|x| x % 2 == 1}
 end
 
 
-a = [2,2,3,5,6,7,14,8,9,7,10,12]
+a = [2,2,3,5,7,1,6,7,14,8,9,7,10,12]
 
 print remove_odd_numbers_from_array(a)

--- a/incorrect_array_remove_method/incorrect_array_remove_method.rb
+++ b/incorrect_array_remove_method/incorrect_array_remove_method.rb
@@ -1,0 +1,22 @@
+# removing all odd numbers from an array
+
+# def remove_odd_numbers_from_array(a)
+#   a.each do |x|
+#       if x%2!=0
+#           a.delete x
+#       end
+#   end
+#   return a
+# end
+
+# This method does not work as expected. Can you correct it
+
+#removing all odd numbers from an array
+def remove_odd_numbers_from_array(a)
+  a.delete_if{|x| x % 2 == 1}
+end
+
+
+a = [2,2,3,5,6,7,14,8,9,7,10,12]
+
+print remove_odd_numbers_from_array(a)


### PR DESCRIPTION
You come across a method for removing all odd numbers from an array

removing all odd numbers from an array

def remove_odd_numbers_from_array(a)
  a.each do |x|
      if x%2!=0
          a.delete x
      end
  end
  return a
end

This method does not work as expected. Can you correct it
(There is a bug here)
